### PR TITLE
Fixes for external use cases

### DIFF
--- a/tdlbcpp/src/ComputeUnit.h
+++ b/tdlbcpp/src/ComputeUnit.h
@@ -49,8 +49,8 @@
 
 template <typename T, int QVecSize, MemoryLayoutType MemoryLayout>
 class ComputeUnitBase {
-    using Fld = Field<T, QVecSize, MemoryLayout>;
 public:
+    using Fld = Field<T, QVecSize, MemoryLayout>;
     
     //Position in the grid
     int idi, idj, idk;

--- a/tdlbcpp/src/DiskOutputTree.h
+++ b/tdlbcpp/src/DiskOutputTree.h
@@ -126,7 +126,7 @@ public:
         output = output1.getJson();
         checkpoint = checkpoint1.getJson();
         
-    };
+    }
         
     void setComputeUnitParams(ComputeUnitParams cu1) {
         cu = cu1;
@@ -135,7 +135,7 @@ public:
 
     void setGridParams(GridParams grid1){
         grid = grid1.getJson();
-    };
+    }
 
     template <typename T>
     void setFlowParams(FlowParams<T> flow1) {

--- a/tdlbcpp/src/Field.hpp
+++ b/tdlbcpp/src/Field.hpp
@@ -1,4 +1,3 @@
-
 #include "Header.h"
 #include "QVec.hpp"
 
@@ -62,7 +61,7 @@ struct QVecAccessBase<T, QVecSize, MemoryLayoutLIJK>
 
     inline operator QVec<T, QVecSize>()
     {
-        return QVec<T, QVecSize>(q, ijkSize);
+        return QVec<T, QVecSize>(q.q, ijkSize);
     }
 
     inline QVecAccessBase<T, QVecSize, MemoryLayoutLIJK> &operator=(const QVec<T, QVecSize> &v)

--- a/tdlbcpp/src/Params/ComputeUnitParams.hpp
+++ b/tdlbcpp/src/Params/ComputeUnitParams.hpp
@@ -30,8 +30,11 @@ struct ComputeUnitParams
     tNi j0 = 0;
     tNi k0 = 0;
     tNi ghost = 0;
-    
 
+    ComputeUnitParams() {}
+
+    ComputeUnitParams(int idi, int idj, int idk, tNi x, tNi y, tNi z, tNi i0, tNi j0, tNi k0, tNi ghost)
+     : idi(idi), idj(idj), idk(idk), x(x), y(y), z(z), i0(i0), j0(j0), k0(k0), ghost(ghost) {}
         
     void getParamsFromJson(Json::Value jsonParams) {
         

--- a/tdlbcpp/src/QVec.hpp
+++ b/tdlbcpp/src/QVec.hpp
@@ -104,7 +104,7 @@ private:
 
     inline void copy(const T* qFrom, size_t step) {
         for (int l = 0; l < size; l++) {
-            q[l] = qFrom + l * step;
+            q[l] = *(qFrom + l * step);
         }
     }
     

--- a/tdlbcpp/src/main.cpp
+++ b/tdlbcpp/src/main.cpp
@@ -98,21 +98,29 @@ int main(int argc, char* argv[]){
 
     std::cout << "Debug: inputJsonPath, checkpointPath" << inputJsonPath << checkpointPath << std::endl;
 
+    bool parametersLoadedFromJson = false;
     if (inputJsonPath != "") {
-        std::cout << "Loading " << inputJsonPath << std::endl;
+        try {
+            std::cout << "Loading " << inputJsonPath << std::endl;
 
-        std::ifstream in(inputJsonPath.c_str());
-        Json::Value jsonParams;
-        in >> jsonParams;
-        in.close();
+            std::ifstream in(inputJsonPath.c_str());
+            Json::Value jsonParams;
+            in >> jsonParams;
+            in.close();
 
-        grid.getParamsFromJson(jsonParams["GridParams"]);
-        flow.getParamsFromJson(jsonParams["FlowParams"]);
-        running.getParamsFromJson(jsonParams["RunningParams"]);
-        output.getParamsFromJson(jsonParams["OutputParams"]);
-        checkpoint.getParamsFromJson(jsonParams["CheckpointParams"]);
+            grid.getParamsFromJson(jsonParams["GridParams"]);
+            flow.getParamsFromJson(jsonParams["FlowParams"]);
+            running.getParamsFromJson(jsonParams["RunningParams"]);
+            output.getParamsFromJson(jsonParams["OutputParams"]);
+            checkpoint.getParamsFromJson(jsonParams["CheckpointParams"]);
+            parametersLoadedFromJson = true;
+        } catch (std::exception &e) {
+            std::cerr << "Exception reached parsing input json: "
+                        << e.what() << ", will use default parameters" << std::endl;
+        }
+    }
 
-    } else {
+    if (!parametersLoadedFromJson) {
 
         grid.y = grid.x;
         grid.z = grid.x;


### PR DESCRIPTION
1. make Fld type public in ComputeUnitBase class (to be used by clients)
2. remove extra semicolons
3. operator of creating QVec from QVecAccess (for lijk memory layout) had a bug
4. ComputeUnitParams constructor added
5. execution failed when -j parameter used for non-existent json
6. QVec copy from pointer of values had a bug